### PR TITLE
WPCS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[{*.txt,wp-config-sample.php}]
+end_of_line = crlf

--- a/api.php
+++ b/api.php
@@ -51,7 +51,7 @@ add_action( 'wp_enqueue_scripts', 'consent_api_enqueue_assets', 9999 );
  * @return bool|string $consent_type
  */
 function wp_validate_consent_type( $consent_type ) {
-	if ( in_array( $consent_type, WP_CONSENT_API()->config->consent_types() ) ) {
+	if ( in_array( $consent_type, WP_CONSENT_API()->config->consent_types(), true ) ) {
 		return $consent_type;
 	}
 
@@ -66,7 +66,7 @@ function wp_validate_consent_type( $consent_type ) {
  * @return bool|string $consent_value
  */
 function wp_validate_consent_value( $consent_value ) {
-	if ( in_array( $consent_value, WP_CONSENT_API()->config->consent_values() ) ) {
+	if ( in_array( $consent_value, WP_CONSENT_API()->config->consent_values(), true ) ) {
 		return $consent_value;
 	}
 	return false;
@@ -80,7 +80,7 @@ function wp_validate_consent_value( $consent_value ) {
  * @return bool|string $consent_category
  */
 function wp_validate_consent_category( $consent_category ) {
-	if ( in_array( $consent_category, WP_CONSENT_API()->config->consent_categorys() ) ) {
+	if ( in_array( $consent_category, WP_CONSENT_API()->config->consent_categorys(), true ) ) {
 		return $consent_category;
 	}
 

--- a/api.php
+++ b/api.php
@@ -1,6 +1,9 @@
-<?php
-defined( 'ABSPATH' ) or die( "you do not have acces to this page!" );
+<?php // phpcs:ignore -- Ignore the "\r\n" notice for some machines.
 
+// Check that the file is not accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'We\'re sorry, but you can not directly access this file.' );
+}
 
 /**
  * Enqueue scripts for the api for front-end
@@ -15,56 +18,55 @@ defined( 'ABSPATH' ) or die( "you do not have acces to this page!" );
  *
  * @param $hook
  */
-
 function consent_api_enqueue_assets( $hook ) {
 	$minified = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
-	wp_enqueue_script( 'wp-consent-api', CONSENT_API_URL . "assets/js/wp-consent-api$minified.js", array('jquery'), CONSENT_API_VERSION, true );
+	wp_enqueue_script( 'wp-consent-api', CONSENT_API_URL . "assets/js/wp-consent-api$minified.js", array( 'jquery' ), CONSENT_API_VERSION, true );
 
 	//we can pass a default or static consent type to the javascript
 	$consent_type = wp_get_consent_type();
 
 	//when the consenttype (optin or optout) can be set dynamically, we can tell plugins to wait in the javascript until the consenttype has been determined
-	$waitfor_consent_hook = apply_filters('wp_consent_api_waitfor_consent_hook', false);
+	$waitfor_consent_hook = apply_filters( 'wp_consent_api_waitfor_consent_hook', false );
 
 	//the cookie expiration for the front-end consent cookies
 	$expiration = wp_consent_api_cookie_expiration();
+
 	wp_localize_script(
 		'wp-consent-api',
 		'consent_api',
 		array(
-			'consent_type' => $consent_type,
+			'consent_type'         => $consent_type,
 			'waitfor_consent_hook' => $waitfor_consent_hook,
-			'cookie_expiration' => $expiration,
+			'cookie_expiration'    => $expiration,
 		)
 	);
 }
-
-add_action( 'wp_enqueue_scripts', 'consent_api_enqueue_assets' , 9999);
-
+add_action( 'wp_enqueue_scripts', 'consent_api_enqueue_assets', 9999 );
 
 /**
  * Validate consent_type
+ *
  * @param $consent_type
  *
  * @return bool|string $consent_type
  */
-
-function wp_validate_consent_type($consent_type){
-	if (in_array($consent_type, WP_CONSENT_API()->config->consent_types() )){
+function wp_validate_consent_type( $consent_type ) {
+	if ( in_array( $consent_type, WP_CONSENT_API()->config->consent_types() ) ) {
 		return $consent_type;
 	}
+
 	return false;
 }
 
 /**
  * Validate consent_value
+ *
  * @param $consent_value
  *
  * @return bool|string $consent_value
  */
-
-function wp_validate_consent_value($consent_value){
-	if (in_array($consent_value, WP_CONSENT_API()->config->consent_values() )){
+function wp_validate_consent_value( $consent_value ) {
+	if ( in_array( $consent_value, WP_CONSENT_API()->config->consent_values() ) ) {
 		return $consent_value;
 	}
 	return false;
@@ -72,82 +74,81 @@ function wp_validate_consent_value($consent_value){
 
 /**
  * Validate consent_category
+ *
  * @param $consent_category
  *
  * @return bool|string $consent_category
  */
-
-function wp_validate_consent_category($consent_category){
-	if (in_array($consent_category, WP_CONSENT_API()->config->consent_categorys() )){
+function wp_validate_consent_category( $consent_category ) {
+	if ( in_array( $consent_category, WP_CONSENT_API()->config->consent_categorys() ) ) {
 		return $consent_category;
 	}
+
 	return false;
 }
 
 /**
  * Get active consent_type
+ *
  * @return string $consent_type
  */
 function wp_get_consent_type() {
-
-	return apply_filters('wp_get_consent_type', FALSE);
+	return apply_filters( 'wp_get_consent_type', false );
 }
 
 /**
- * filterable, to allow for use in combination with consent_type
+ * Filterable, to allow for use in combination with consent_type
  * return value of wp_consent$level cookie (false, deny or allow)
  *
  * @param $consent_category
+ *
  * @return bool $has_consent
  */
-
 function wp_has_consent( $consent_category ) {
-	$consent_type = wp_get_consent_type();
-	$consent_category = wp_validate_consent_category($consent_category);
+	$consent_type     = wp_get_consent_type();
+	$consent_category = wp_validate_consent_category( $consent_category );
 
-	if (!$consent_type) {
+	if ( ! $consent_type ) {
 		//if consent_type is not set, there's no consent management, we should return true to activate all cookies
 		$has_consent_level = true;
-
-	} else if (strpos($consent_type, 'optout')!==FALSE && !isset($_COOKIE["wp_consent_$consent_category"]) || !$_COOKIE["wp_consent_$consent_category"]) {
+	} elseif ( strpos( $consent_type, 'optout' ) !== false && ! isset( $_COOKIE[ "wp_consent_$consent_category" ] ) || ! $_COOKIE[ "wp_consent_$consent_category" ] ) {
 		//if it's opt out and no cookie is set or it's false, we should also return true
 		$has_consent_level = true;
-
-	}else if (isset($_COOKIE["wp_consent_$consent_category"]) && $_COOKIE["wp_consent_$consent_category"] ==='allow'){
+	} elseif ( isset( $_COOKIE[ "wp_consent_$consent_category" ] ) && 'allow' === $_COOKIE[ "wp_consent_$consent_category" ] ) {
 		//all other situations, return only true if value is allow
 		$has_consent_level = true;
 	} else {
 		$has_consent_level = false;
 	}
 
-	return apply_filters('wp_has_consent', $has_consent_level, $consent_category);
+	return apply_filters( 'wp_has_consent', $has_consent_level, $consent_category );
 }
 
 /**
  * Get cookie expiration
+ *
  * @return int expiration in seconds
  */
-
-function wp_consent_api_cookie_expiration(){
-	return apply_filters('wp_consent_api_cookie_expiration', WP_CONSENT_API()->config->cookie_expiration_days());
+function wp_consent_api_cookie_expiration() {
+	return apply_filters( 'wp_consent_api_cookie_expiration', WP_CONSENT_API()->config->cookie_expiration_days() );
 }
 
 /**
- * set accepted consent category
+ * Set accepted consent category
  *
  * @param string $consent_category
  * @param string $value (allow|deny)
  */
 
 function wp_set_consent( $consent_category, $value ) {
-	$consent_category = apply_filters('wp_set_consent_type', $consent_category);
-	$value = apply_filters('wp_set_consent_value', $value);
+	$consent_category = apply_filters( 'wp_set_consent_type', $consent_category );
+	$value            = apply_filters( 'wp_set_consent_value', $value );
 
-	$expiration = wp_consent_api_cookie_expiration() * DAY_IN_SECONDS;
-	$consent_category =  wp_validate_consent_category($consent_category);
-	$value =  wp_validate_consent_value($value);
+	$expiration       = wp_consent_api_cookie_expiration() * DAY_IN_SECONDS;
+	$consent_category = wp_validate_consent_category( $consent_category );
+	$value            = wp_validate_consent_value( $value );
 
-	setcookie("wp_consent_$consent_category", $value, time() + $expiration, '/');
+	setcookie( "wp_consent_$consent_category", $value, time() + $expiration, '/' );
 }
 
 /**
@@ -157,6 +158,6 @@ function wp_set_consent( $consent_category, $value ) {
  * @return bool $registered
  */
 
-function consent_api_registered($plugin){
-	return apply_filters("wp_consent_api_registered_$plugin", false);
+function consent_api_registered( $plugin ) {
+	return apply_filters( "wp_consent_api_registered_$plugin", false );
 }

--- a/class-site-health.php
+++ b/class-site-health.php
@@ -1,19 +1,22 @@
-<?php
-defined('ABSPATH') or die("you do not have access to this page!");
+<?php // phpcs:ignore -- Ignore the wrong filename (class- prefix) & "\r\n" notice for some machines.
 
-if (!class_exists("CONSENT_API_SITE_HEALTH")) {
+// Check that the file is not accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'We\'re sorry, but you can not directly access this file.' );
+}
+
+if ( ! class_exists( 'CONSENT_API_SITE_HEALTH' ) ) {
 	class CONSENT_API_SITE_HEALTH {
 
 		private static $_this;
 
 		function __construct() {
-
 			if ( isset( self::$_this ) ) {
+				// translators: %s the name of the PHP Class used.
 				wp_die( sprintf( __( '%s is a singleton class and you cannot create a second instance.', 'really-simple-ssl' ), get_class( $this ) ) );
-
 			}
 
-			add_filter( 'site_status_tests', array($this, 'consent_api_integration_check' ) );
+			add_filter( 'site_status_tests', array( $this, 'consent_api_integration_check' ) );
 
 			self::$_this = $this;
 		}
@@ -25,22 +28,24 @@ if (!class_exists("CONSENT_API_SITE_HEALTH")) {
 		public function consent_api_integration_check( $tests ) {
 			$tests['direct']['wp-consent-api'] = array(
 				'label' => __( 'WP Consent API test' ),
-				'test'  => array($this, "consent_api_test"),
+				'test'  => array( $this, 'consent_api_test' ),
 			);
 
 			return $tests;
 		}
 
 		public function consent_api_test() {
-			$plugins = get_option('active_plugins');
-			$not_registered = array();
+			$plugins                      = get_option( 'active_plugins' );
+			$not_registered               = array();
 			$plugins_without_registration = false;
-			foreach ($plugins as $plugin){
-				if (!consent_api_registered($plugin)){
-					$not_registered[] = $plugin;
+
+			foreach ( $plugins as $plugin ) {
+				if ( ! consent_api_registered( $plugin ) ) {
+					$not_registered[]             = $plugin;
 					$plugins_without_registration = true;
 				}
 			}
+
 			$result = array(
 				'label'       => __( 'All plugins have declared to use the Consent API', 'really-simple-ssl' ),
 				'status'      => 'good',
@@ -56,17 +61,14 @@ if (!class_exists("CONSENT_API_SITE_HEALTH")) {
 				'test'        => 'wp-consent-api',
 			);
 
-			if ($plugins_without_registration) {
+			if ( $plugins_without_registration ) {
 				$result['status']      = 'recommended';
 				$result['label']       = __( 'One or more plugins are not conforming to the Consent API.', 'wp-consent-api' );
-				$result['description'] = __( 'Not all plugins have declared to follow Consent API guidelines. Please contact the developer.', 'wp-consent-api');
-				$result['actions'] = implode('<br>', $not_registered);
-
+				$result['description'] = __( 'Not all plugins have declared to follow Consent API guidelines. Please contact the developer.', 'wp-consent-api' );
+				$result['actions']     = implode( '<br>', $not_registered );
 			}
 
-
 			return $result;
-
 		}
 	}
 }

--- a/config.php
+++ b/config.php
@@ -1,85 +1,79 @@
-<?php
-defined('ABSPATH') or die("you do not have acces to this page!");
+<?php // phpcs:ignore -- Ignore the missing class- prefix from file & "\r\n" notice for some machines.
 
-if (!class_exists("CONSENT_API_CONFIG")) {
-	class CONSENT_API_CONFIG
-	{
+// Check that the file is not accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'We\'re sorry, but you can not directly access this file.' );
+}
+
+if ( ! class_exists( 'CONSENT_API_CONFIG' ) ) {
+	class CONSENT_API_CONFIG {
+
 		private static $_this;
 
-
-
-		function __construct()
-		{
-			if (isset(self::$_this))
-				wp_die(sprintf(__('%s is a singleton class and you cannot create a second instance.', 'complianz-gdpr'), get_class($this)));
+		function __construct() {
+			if ( isset( self::$_this ) ) {
+				// translators: %s the name of the PHP Class used.
+				wp_die( sprintf( __( '%s is a singleton class and you cannot create a second instance.', 'complianz-gdpr' ), get_class( $this ) ) );
+			}
 
 			self::$_this = $this;
-
 		}
 
-
-		static function this()
-		{
+		static function this() {
 			return self::$_this;
 		}
 
 		/**
 		 * Get list if active consent_types
+		 *
 		 * @return array() $consent_types
 		 */
 
-		public function consent_types()
-		{
+		public function consent_types() {
 			$consent_types = array(
 				'optin',
 				'optout',
 			);
 
-			return apply_filters('wp_consent_types', $consent_types);
+			return apply_filters( 'wp_consent_types', $consent_types );
 		}
-
 
 		/**
 		 * Get list if active consent_categories
+		 *
 		 * @return array() $consent_categories
 		 */
-
-		public function consent_categories()
-		{
-			return apply_filters('wp_consent_categories',
+		public function consent_categories() {
+			return apply_filters(
+				'wp_consent_categories',
 				array(
-				'functional',
-				'preferences',
-				'statistics',
-				'statistics-anonymous',
-				'statistics',
-				'marketing',
+					'functional',
+					'preferences',
+					'statistics',
+					'statistics-anonymous',
+					'statistics',
+					'marketing',
 				)
 			);
 		}
 
-
 		/**
 		 * Get list of possible consent_values
+		 *
 		 * @return array() $consent_values
 		 */
-
-		public function consent_values()
-		{
+		public function consent_values() {
 			$consent_values = array(
 				'allow',
 				'deny',
 			);
 
-			return apply_filters('wp_consent_values', $consent_values);
+			return apply_filters( 'wp_consent_values', $consent_values );
 		}
 
 
-		public function cookie_expiration_days(){
-			return apply_filters('wp_cookie_expiration', 30);
+		public function cookie_expiration_days() {
+			return apply_filters( 'wp_cookie_expiration', 30 );
 		}
-
-
-
 	}
-} //class closure
+}

--- a/example-plugin/example-plugin.php
+++ b/example-plugin/example-plugin.php
@@ -1,4 +1,5 @@
-<?php
+<?php // phpcs:ignore -- Ignore the "\r\n" notice for some machines.
+
 /**
  * Plugin Name: Example plugin for the WP Consent Level API
  * Plugin URI: https://www.wordpress.org/plugins/wp-consent-api
@@ -10,30 +11,33 @@
  * Author URI:
  */
 
-
 /**
  * Tell the consent API we're following the api guidelines
  */
-$plugin = plugin_basename(__FILE__);
-add_filter("wp_consent_api_registered_$plugin", function(){return true;});
+$plugin = plugin_basename( __FILE__ );
 
+add_filter(
+	"wp_consent_api_registered_$plugin",
+	function() {
+		return true;
+	}
+);
 
 add_action( 'wp_enqueue_scripts', 'example_plugin_enqueue_assets' );
 function example_plugin_enqueue_assets( $hook ) {
-	wp_enqueue_script( 'example-plugin', plugin_dir_url(__FILE__) . "main.js", array('jquery'), CONSENT_API_VERSION, true );
+	wp_enqueue_script( 'example-plugin', plugin_dir_url( __FILE__ ) . 'main.js', array( 'jquery' ), CONSENT_API_VERSION, true );
 }
 
-add_shortcode('example-plugin-shortcode', 'example_plugin_load_document');
+add_shortcode( 'example-plugin-shortcode', 'example_plugin_load_document' );
 
-function example_plugin_load_document($atts = [], $content = null, $tag = '')
-{
-	$atts = array_change_key_case((array)$atts, CASE_LOWER);
+function example_plugin_load_document( $atts = array(), $content = null, $tag = '' ) {
+	$atts = array_change_key_case( (array) $atts, CASE_LOWER );
 	ob_start();
 
 	// override default attributes with user attributes
-	$atts = shortcode_atts(['type' => false,], $atts, $tag);
-
+	$atts = shortcode_atts( array( 'type' => false ), $atts, $tag );
 	?>
+
 	<div id="example-plugin-content">
 		<div class="functional-content">
 			<h1>No consent has been given yet. </h1>
@@ -41,7 +45,6 @@ function example_plugin_load_document($atts = [], $content = null, $tag = '')
 		<div class="marketing-content" style="display:none">
 			<h1>Woohoo! let's start tracking you :)</h1>
 		</div>
-
 	</div>
 
 	<?php

--- a/wordpress-comments.php
+++ b/wordpress-comments.php
@@ -1,4 +1,5 @@
-<?php
+<?php // phpcs:ignore -- Ignore the  "\r\n" notice for some machines.
+
 /**
  * Instead of listening to the consent checkbox, this function checks for the "preferences" consent
  *
@@ -6,42 +7,38 @@
  * if preferences is set, the comments cookies function gets passed a $cookies_consent=true, so cookies can be set. Otherwise, it's false.
  */
 
-
 /**
- * first we remove the default comment cookies action, and replace with our own
+ * First we remove the default comment cookies action, and replace with our own
  * we add custom comment cookies action, which checks the consent, then calls the comment cookie function in wp
  */
 
-function wp_consent_api_wordpress_comments_cookies(){
+function wp_consent_api_wordpress_comments_cookies() {
 
-	//remove default wp action
-	remove_action( 'set_comment_cookies', 'wp_set_comment_cookies', 10);
+	// Remove default wp action.
+	remove_action( 'set_comment_cookies', 'wp_set_comment_cookies', 10 );
 
-	//add our own custom action
-	add_action( 'set_comment_cookies', 'wp_consent_api_set_comment_cookies', 10, 3);
+	// Add our own custom action.
+	add_action( 'set_comment_cookies', 'wp_consent_api_set_comment_cookies', 10, 3 );
 
-	//remove checkbox
-	add_filter('comment_form_default_fields', 'wp_consent_api_wordpress_comment_form_hide_cookies_consent');
+	// Remove checkbox.
+	add_filter( 'comment_form_default_fields', 'wp_consent_api_wordpress_comment_form_hide_cookies_consent' );
 
 }
-add_action('init', 'wp_consent_api_wordpress_comments_cookies');
-
+add_action( 'init', 'wp_consent_api_wordpress_comments_cookies' );
 
 /**
- * custom consent function, checking consent level to decide if cookies can be set.
+ * Custom consent function, checking consent level to decide if cookies can be set.
  */
-function wp_consent_api_set_comment_cookies($comment, $user, $cookies_consent){
-	$cookies_consent = wp_has_consent('preference');
+function wp_consent_api_set_comment_cookies( $comment, $user, $cookies_consent ) {
+	$cookies_consent = wp_has_consent( 'preference' );
 	wp_set_comment_cookies( $comment, $user, $cookies_consent );
 }
-
 
 /**
  * Remove consent checkbox
  * @param $fields
  *
  * @return array $fields
- *
  */
 
 function wp_consent_api_wordpress_comment_form_hide_cookies_consent( $fields ) {

--- a/wp-consent-api.php
+++ b/wp-consent-api.php
@@ -1,4 +1,5 @@
-<?php
+<?php // phpcs:ignore -- Ignore the missing class- prefix from file.
+
 /**
  * Plugin Name: WP Consent Level API
  * Plugin URI:  https://www.wordpress.org/plugins/wp-consent-api
@@ -25,110 +26,96 @@
  * along with this program. If not, see https://www.gnu.org/licenses/.
  */
 
-defined('ABSPATH') or die("you do not have access to this page!");
+// Check that the file is not accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'We\'re sorry, but you can not directly access this file.' );
+}
 
 
 /**
  * Checks if the plugin can safely be activated, at least php 5.6 and wp 5.0
  * @since 1.0.0
  */
-if (!function_exists('consent_api_activation_check')) {
-    function consent_api_activation_check()
-    {
-        if (version_compare(PHP_VERSION, '5.6', '<')) {
-            deactivate_plugins(plugin_basename(__FILE__));
-            wp_die(__('This plugin requires PHP 5.6 or higher', 'wp-consent-api'));
-        }
+if ( ! function_exists( 'consent_api_activation_check' ) ) {
+	function consent_api_activation_check() {
+		if ( version_compare( PHP_VERSION, '5.6', '<' ) ) {
+			deactivate_plugins( plugin_basename( __FILE__ ) );
+			wp_die( __( 'This plugin requires PHP 5.6 or higher', 'wp-consent-api' ) );
+		}
 
-        global $wp_version;
-        if (version_compare($wp_version, '5.0', '<')) {
-            deactivate_plugins(plugin_basename(__FILE__));
-            wp_die(__('This plugin requires WordPress 5.0 or higher', 'wp-consent-api'));
-        }
-    }
+		global $wp_version;
+
+		if ( version_compare( $wp_version, '5.0', '<' ) ) {
+			deactivate_plugins( plugin_basename( __FILE__ ) );
+			wp_die( __( 'This plugin requires WordPress 5.0 or higher', 'wp-consent-api' ) );
+		}
+	}
 }
 register_activation_hook( __FILE__, 'consent_api_activation_check' );
 
 
-if (!class_exists('WP_CONSENT_API')) {
-    class WP_CONSENT_API
-    {
+if ( ! class_exists( 'WP_CONSENT_API' ) ) {
+	class WP_CONSENT_API {
 
-        private static $instance;
+		private static $instance;
 
+		private function __construct() {
+		}
 
-        private function __construct()
-        {
-        }
+		public static function instance() {
+			if ( ! isset( self::$instance ) && ! ( self::$instance instanceof WP_CONSENT_API ) ) {
+				self::$instance = new WP_CONSENT_API;
 
-        public static function instance()
-        {
+				self::$instance->setup_constants();
+				self::$instance->includes();
 
-            if (!isset(self::$instance) && !(self::$instance instanceof WP_CONSENT_API)) {
-                self::$instance = new WP_CONSENT_API;
+				self::$instance->config      = new CONSENT_API_CONFIG();
+				self::$instance->site_health = new CONSENT_API_SITE_HEALTH();
 
-                self::$instance->setup_constants();
-                self::$instance->includes();
+				self::$instance->hooks();
+			}
 
-                self::$instance->config = new CONSENT_API_CONFIG();
-                self::$instance->site_health = new CONSENT_API_SITE_HEALTH();
+			return self::$instance;
+		}
 
-                self::$instance->hooks();
-            }
+		private function setup_constants() {
+			require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+			$plugin_data = get_plugin_data( __FILE__ );
 
-            return self::$instance;
-        }
+			define( 'CONSENT_API_URL', plugin_dir_url( __FILE__ ) );
+			define( 'CONSENT_API_PATH', plugin_dir_path( __FILE__ ) );
+			define( 'CONSENT_API_PLUGIN', plugin_basename( __FILE__ ) );
+			$debug = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? time() : '';
+			define( 'CONSENT_API_VERSION', $plugin_data['Version'] . $debug );
+			define( 'CONSENT_API_PLUGIN_FILE', __FILE__ );
+		}
 
-        private function setup_constants()
-        {
-            require_once(ABSPATH . 'wp-admin/includes/plugin.php');
-            $plugin_data = get_plugin_data(__FILE__);
+		private function includes() {
+			require_once( CONSENT_API_PATH . 'config.php' );
+			require_once( CONSENT_API_PATH . 'api.php' );
+			require_once( CONSENT_API_PATH . 'class-site-health.php' );
+			require_once( CONSENT_API_PATH . 'wordpress-comments.php' );
+		}
 
-            define('CONSENT_API_URL', plugin_dir_url(__FILE__));
-            define('CONSENT_API_PATH', plugin_dir_path(__FILE__));
-            define('CONSENT_API_PLUGIN', plugin_basename(__FILE__));
-            $debug = (defined('SCRIPT_DEBUG') && SCRIPT_DEBUG) ? time() : '';
-            define('CONSENT_API_VERSION', $plugin_data['Version'] . $debug);
-            define('CONSENT_API_PLUGIN_FILE', __FILE__);
-        }
-
-        private function includes()
-        {
-
-            require_once(CONSENT_API_PATH . 'config.php');
-            require_once(CONSENT_API_PATH . 'api.php');
-            require_once(CONSENT_API_PATH . 'class-site-health.php');
-
-            require_once(CONSENT_API_PATH . 'wordpress-comments.php');
-        }
-
-        private function hooks()
-        {
-
-        }
-    }
+		private function hooks() {
+		}
+	}
 }
 
-if (!function_exists('WP_CONSENT_API')) {
-    function WP_CONSENT_API() {
-        return WP_CONSENT_API::instance();
-    }
+if ( ! function_exists( 'WP_CONSENT_API' ) ) {
+	function WP_CONSENT_API() { // phpcs:ignore -- Ignore not snakecase name.
+		return WP_CONSENT_API::instance();
+	}
 
-    add_action( 'plugins_loaded', 'WP_CONSENT_API', 9 );
+	add_action( 'plugins_loaded', 'WP_CONSENT_API', 9 );
 }
-
-
 
 /**
  * Load the translation files
- *
  */
-
-if (!function_exists('consent_api_load_translation')) {
-    add_action('init', 'consent_api_load_translation', 20);
-    function consent_api_load_translation()
-    {
-        load_plugin_textdomain('wp-consent-api', FALSE, CONSENT_API_PATH . '/config/languages/');
-    }
+if ( ! function_exists( 'consent_api_load_translation' ) ) {
+	add_action( 'init', 'consent_api_load_translation', 20 );
+	function consent_api_load_translation() {
+		load_plugin_textdomain( 'wp-consent-api', false, CONSENT_API_PATH . '/config/languages/' );
+	}
 }
-

--- a/wp-consent-api.php
+++ b/wp-consent-api.php
@@ -1,4 +1,4 @@
-<?php // phpcs:ignore -- Ignore the missing class- prefix from file.
+<?php // phpcs:ignore -- Ignore the missing class- prefix from file & "\r\n" notice for some machines.
 
 /**
  * Plugin Name: WP Consent Level API

--- a/wp-consent-api.php
+++ b/wp-consent-api.php
@@ -1,31 +1,29 @@
 <?php
 /**
  * Plugin Name: WP Consent Level API
- * Plugin URI: https://www.wordpress.org/plugins/wp-consent-api
+ * Plugin URI:  https://www.wordpress.org/plugins/wp-consent-api
  * Description: Simple Consent Level API to read and register the current consent level
- * Version: 1.0.0
+ * Version:     1.0.0
  * Text Domain: wp-consent-api
  * Domain Path: /languages
- * Author: WP privacy team
- * Author URI:
+ * Author:      WP privacy team
+ * Author URI: https://github.com/rlankhorst/wp-consent-level-api
  */
 
-/*
-
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License, version 2, as
-    published by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-
-*/
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see https://www.gnu.org/licenses/.
+ */
 
 defined('ABSPATH') or die("you do not have access to this page!");
 


### PR DESCRIPTION
Fixes licensing info ( The GPLv2 licenses uses a non-existence address anymore so I simply changed the last wording to point people to the site if license is missing similar to what GPLv3 does ).

Fixes code against latest WPCS.

Adds an `.editorconfig` file so common editors can use the standard configurations i.e. tabs not spaces etc.

You will find 1 commit for each file ( well I tried to keep it that way at least haha ).

Some files include some `// phpcs:ignore` comments when needed to avoid typical notices ( these can be fixed in the future 😊 i.e. naming files with class- prefixes etc.

I've added full descriptions of what's changed/altered regarding the code on each commit for an easier review if there was an actual code edit ( i.e. setting true for strict comparisons on in_array() ).

This PR only takes care of `.php` files, I haven't run anything against ESLint/JSHint yet :) 