### PR TITLE
Consent API never read Cookie

### DIFF
--- a/assets/js/wp-consent-api.js
+++ b/assets/js/wp-consent-api.js
@@ -60,7 +60,7 @@ function consent_api_setcookie(name, value) {
 }
 
 function consent_api_get_cookie(cname) {
-    var name = cname + "="; //Create the cookie name variable with cookie name concatenate with = sign
+    var name = "wp_consent_" + cname + "="; //Create the cookie name variable with cookie name concatenate with = sign
     var cArr = window.document.cookie.split(';'); //Create cookie array by split the cookie by ';'
 
     //Loop through the cookies and return the cooki value if it find the cookie name


### PR DESCRIPTION
The consent API never reads the cookie after consent is set. This result in consent always returns true/false (depends on you using optin or optout). Added the required prefix to the cookie to ensure the consent status is actually read from the cookie.