### PR TITLE
Remove duplicate "statistics" category

### DIFF
--- a/config.php
+++ b/config.php
@@ -51,7 +51,6 @@ if ( ! class_exists( 'CONSENT_API_CONFIG' ) ) {
 					'preferences',
 					'statistics',
 					'statistics-anonymous',
-					'statistics',
 					'marketing',
 				)
 			);


### PR DESCRIPTION
The statistics category were mentioned twice in the array. This doesn't affect the plugin - but to make it clear it should only be added once.