### PR TITLE
Update wp-consent-api.js

### DIFF
--- a/assets/js/wp-consent-api.js
+++ b/assets/js/wp-consent-api.js
@@ -92,7 +92,7 @@ function wp_set_consent(category, value) {
     var event;
     if (value !== 'allow' && value !== 'deny') return;
 
-    consent_api_set_cookie('wp_consent_' + category, value);
+    consent_api_set_cookie(category, value);
     var changedConsentCategory = [];
     changedConsentCategory[category] = value;
     try {


### PR DESCRIPTION
Fix: Cookie name contains redundant 'wp_consent'  while setting through JS. Consent prefix is already using while setting the cookie. 

`document.cookie = "wp_consent_" + name + "="`

So removed adding the prefix while calling the set cookie API