### PR TITLE
Drop www. prefix from wordpress.org in Plugin URI

### DIFF
--- a/wp-consent-api.php
+++ b/wp-consent-api.php
@@ -2,7 +2,7 @@
 
 /**
  * Plugin Name: WP Consent API
- * Plugin URI:  https://www.wordpress.org/plugins/wp-consent-api
+ * Plugin URI:  https://wordpress.org/plugins/wp-consent-api
  * Description: Consent Level API to read and register the current consent level
  * Version:     1.0.0
  * Text Domain: wp-consent-api


### PR DESCRIPTION
There's no need for the www prefix as WP.org redirects to the naked domain.