### PR TITLE
Update Plugin Headers

### DIFF
--- a/wp-consent-api.php
+++ b/wp-consent-api.php
@@ -1,14 +1,16 @@
 <?php // phpcs:ignore -- Ignore the missing class- prefix from file & "\r\n" notice for some machines.
 
 /**
- * Plugin Name: WP Consent API
- * Plugin URI:  https://wordpress.org/plugins/wp-consent-api
- * Description: Consent Level API to read and register the current consent level
- * Version:     1.0.0
- * Text Domain: wp-consent-api
- * Domain Path: /languages
- * Author:      RogierLankhorst
- * Author URI: https://github.com/rlankhorst/wp-consent-level-api
+ * Plugin Name:       WP Consent API
+ * Plugin URI:        https://wordpress.org/plugins/wp-consent-api
+ * Description:       Consent Level API to read and register the current consent level for cookie management and improving compliance with privacy laws.
+ * Version:           1.0.0
+ * Author:            RogierLankhorst
+ * Author URI:        https://github.com/rlankhorst/wp-consent-level-api
+ * Requires at least: 4.9.6
+ * Requires PHP:      5.6
+ * License:           GPL2
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.html
  */
 
 /**


### PR DESCRIPTION
Remove Domain Path; "The Domain Path header can be omitted if the plugin is in the official WordPress Plugin Directory." 
Reference - https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#domain-path
Remove Text Domain; "After WordPress 4.6 came out, the Text Domain header is no longer required if it’s the same as the plugin slug. It’s now the default value."
Reference - https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains

Added Requires & License headers.
Note: I went with 4.9.6 as min WP as that's when the privacy tools were released, if there's any core wp functions requiring a later version we can update that.