### PR TITLE
Pass $plugin value to apply_filters

### DIFF
--- a/api.php
+++ b/api.php
@@ -183,7 +183,7 @@ function consent_api_registered( $plugin ) {
 		return true;
 	}
 
-	return apply_filters( "wp_consent_api_registered_$plugin", false );
+	return apply_filters( "wp_consent_api_registered_{$plugin}", false );
 }
 
 /**


### PR DESCRIPTION
I assume here we wanted to pass the plugin registered slug to the filter similar to how WordPress does `"manage_{$screen->id}_columns"`.