### PR TITLE
remove jquery dependency

### DIFF
--- a/api.php
+++ b/api.php
@@ -42,7 +42,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function wp_consent_api_enqueue_assets() {
 	$minified = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
-	wp_enqueue_script( 'wp-consent-api', WP_CONSENT_API_URL . "assets/js/wp-consent-api$minified.js", array( 'jquery' ), WP_CONSENT_API_VERSION, true );
+	wp_enqueue_script( 'wp-consent-api', WP_CONSENT_API_URL . "assets/js/wp-consent-api$minified.js", array(), WP_CONSENT_API_VERSION, true );
 
 	// We can pass a default or static consent type to the javascript.
 	$consent_type = wp_get_consent_type();


### PR DESCRIPTION
fixes #57 
It looks like this is a holdover from an [earlier iteration](https://github.com/rlankhorst/wp-consent-level-api/commit/c16d3f47f3beb5d66cbb9d5bf966a5d861d2e21d#diff-46eeea02642fc062b5711f2badc000b6) of the js file which was [later removed](https://github.com/rlankhorst/wp-consent-level-api/commit/11b18885119f9797286cd4e429cec7693371e6a7#diff-46eeea02642fc062b5711f2badc000b6) in favor of vanilla js. As a result, we don't need this dependency anymore.